### PR TITLE
RequestPost - Enabled POST to /requests

### DIFF
--- a/src/main/java/com/coastcapitalsavings/mvc/controllers/CategoriesController.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/controllers/CategoriesController.java
@@ -38,7 +38,7 @@ public class CategoriesController {
             return new ResponseEntity(response, HttpStatus.OK);
         } catch (DataAccessException e) {
             System.err.println(new Date() + " " +  e.getMessage());     // TODO:  Can be logged by a logger
-            return new ResponseEntity(Responses.INTERNAL_SERVER_ERROR.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity(Responses.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/coastcapitalsavings/mvc/controllers/CategoriesController.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/controllers/CategoriesController.java
@@ -1,19 +1,21 @@
 package com.coastcapitalsavings.mvc.controllers;
 
 
+
 import com.fasterxml.jackson.annotation.JsonView;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessException;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.coastcapitalsavings.mvc.models.Category;
-import com.coastcapitalsavings.mvc.models.modelviews.ModelViews;
-import com.coastcapitalsavings.mvc.repositories.ControllerRepository;
 
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import com.coastcapitalsavings.mvc.models.Category;
+import com.coastcapitalsavings.mvc.models.modelviews.ModelViews;
+import com.coastcapitalsavings.mvc.repositories.CategoryRepository;
+import com.coastcapitalsavings.util.Responses;
 
 import java.util.Date;
 import java.util.List;
@@ -23,11 +25,10 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/categories")
-
 public class CategoriesController {
 
     @Autowired
-    ControllerRepository controllerRepo;
+    CategoryRepository controllerRepo;
 
     @JsonView(ModelViews.Summary.class)
     @RequestMapping(method= RequestMethod.GET)
@@ -37,7 +38,7 @@ public class CategoriesController {
             return new ResponseEntity(response, HttpStatus.OK);
         } catch (DataAccessException e) {
             System.err.println(new Date() + " " +  e.getMessage());     // TODO:  Can be logged by a logger
-            return new ResponseEntity("", HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity(Responses.INTERNAL_SERVER_ERROR.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/coastcapitalsavings/mvc/controllers/RequestsController.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/controllers/RequestsController.java
@@ -1,0 +1,51 @@
+package com.coastcapitalsavings.mvc.controllers;
+
+import com.coastcapitalsavings.mvc.models.Request;
+import com.coastcapitalsavings.mvc.services.RequestService;
+import com.coastcapitalsavings.util.Responses;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+
+/**
+ * Handles all requests to the requests resource
+ */
+@RestController
+@RequestMapping("/requests")
+public class RequestsController {
+    @Autowired
+    RequestService requestService;
+
+    @RequestMapping(method=RequestMethod.POST)
+    public ResponseEntity<Request> postNewRequest(@RequestBody PostBodyInput input) {
+        if (input.products == null) {
+            return new ResponseEntity(Responses.MISSING_REQUIRED_PARAMETER, HttpStatus.BAD_REQUEST);
+        } else if (input.products.length < 1 || input.products.length > 3) {
+            return new ResponseEntity(Responses.INVALID_PARAMETER_LENGTH, HttpStatus.PRECONDITION_FAILED);
+        } else if (input.notes.length() > 255) {
+            return new ResponseEntity(Responses.INVALID_PARAMETER_LENGTH, HttpStatus.PRECONDITION_FAILED);
+        } else {
+            try {
+                Request req = requestService.postNewRequest(input.notes, input.products);
+                return new ResponseEntity(req, HttpStatus.CREATED);
+            } catch (DataAccessException e){
+                System.err.println(new Date() + " " + e.getMessage());
+                return new ResponseEntity(Responses.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    @Data
+    private static class PostBodyInput {        // static class required to work properly for jackson
+        String notes;
+        int[] products;
+    }
+}

--- a/src/main/java/com/coastcapitalsavings/mvc/models/Product.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/models/Product.java
@@ -7,6 +7,6 @@ import lombok.Data;
  */
 @Data
 public class Product {
-    private int id;
+    private long id;
     private String name;
 }

--- a/src/main/java/com/coastcapitalsavings/mvc/models/ProductStatus.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/models/ProductStatus.java
@@ -7,6 +7,6 @@ import lombok.Data;
  */
 @Data
 public class ProductStatus {
-    private int id;
+    private Long id;
     private String status;
 }

--- a/src/main/java/com/coastcapitalsavings/mvc/models/Request.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/models/Request.java
@@ -1,21 +1,39 @@
 package com.coastcapitalsavings.mvc.models;
 
+import com.coastcapitalsavings.util.serializers.JsonTimeStampSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
 
-import java.sql.Date;
-import java.util.Map;
+import java.sql.Timestamp;
+import java.util.List;
 
 /**
  * Represents a request for a set 1-3 products that is submitted by an employee.
  */
 @Data
 public class Request {
-    private int id;
+    private long id;            // seems like MySQL unsigned int == java long
     private String notes;
-    private Date dateCreated;
-    private Employee submittedBy;
-    private Date dateModified;
-    private Employee lastModifiedBy;
-    private RequestStatus requestStatus;
-    private Map<Product, ProductStatus> products;
-}
+    private Timestamp dateCreated;
+    private int submittedBy_employeeId;
+    private Timestamp dateModified;
+    private int lastModifiedBy_employeeId;
+    private long requestStatus_id;
+    private List<RequestProduct> products;       // Storing as a list stops us from having to write a painful map serializer
+
+
+    // These two methods are supplied so that we can use a custom serializer
+    // to return a string instead of a millisecond count
+
+    @JsonSerialize(using=JsonTimeStampSerializer.class)
+    public Timestamp getDateCreated() {
+        return dateCreated;
+    }
+
+    @JsonSerialize(using=JsonTimeStampSerializer.class)
+    public Timestamp getDateModified() {
+        return dateModified;
+    }
+};
+
+

--- a/src/main/java/com/coastcapitalsavings/mvc/models/RequestProduct.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/models/RequestProduct.java
@@ -1,0 +1,12 @@
+package com.coastcapitalsavings.mvc.models;
+
+import lombok.Data;
+
+/**
+ * A product in a request
+ */
+@Data
+public class RequestProduct {
+    Product product;
+    long productStatus_id;
+}

--- a/src/main/java/com/coastcapitalsavings/mvc/repositories/CategoryRepository.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/repositories/CategoryRepository.java
@@ -1,12 +1,16 @@
 package com.coastcapitalsavings.mvc.repositories;
 
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
 import com.coastcapitalsavings.mvc.models.Category;
+
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.PreparedStatementCallback;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.stereotype.Repository;
+
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -15,10 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Created by Chris on 2017-02-20.
+ * Data access object for categories endpoint
  */
 @Repository
-public class ControllerRepository {
+public class CategoryRepository {
 
     @Autowired
     JdbcTemplate jdbcTemplate;
@@ -43,7 +47,7 @@ public class ControllerRepository {
         });
     }
 
-    class CategoriesRowMapper implements RowMapper<Category> {
+    private static class CategoriesRowMapper implements RowMapper<Category> {
 
         @Override
         public Category mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/src/main/java/com/coastcapitalsavings/mvc/repositories/RequestRepository.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/repositories/RequestRepository.java
@@ -1,0 +1,203 @@
+package com.coastcapitalsavings.mvc.repositories;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import com.coastcapitalsavings.mvc.models.Product;
+import com.coastcapitalsavings.mvc.models.Request;
+import com.coastcapitalsavings.mvc.models.RequestProduct;
+import org.apache.tomcat.jdbc.pool.DataSource;
+
+import org.springframework.dao.TypeMismatchDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlInOutParameter;
+import org.springframework.jdbc.core.SqlOutParameter;
+import org.springframework.jdbc.core.SqlParameter;
+import org.springframework.jdbc.object.StoredProcedure;
+
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Database access object for the requests endpoint
+ */
+@Repository
+public class RequestRepository {
+
+    JdbcTemplate jdbcTemplate;
+
+    // Store procedures so that they don't have to be recompiled for every use;
+    PostNewRequestStoredProc postNewRequestStoredProc;
+    AddProductToRequestStoredProc addProductToRequestStoredProc;
+
+    @Autowired
+    /*
+    Tricky:  Need to do this instead of autowiring the Jdbc template so that we can ensure that the
+    template is up before the stored procedures are initialized.
+     */
+    public void setDataSource(DataSource dataSource) {
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        postNewRequestStoredProc = new PostNewRequestStoredProc();
+        addProductToRequestStoredProc = new AddProductToRequestStoredProc();
+    }
+
+
+    /**
+     * Handles request posts by invoking a stored procedure
+     * @param reqToPost request object to post without id set
+     * @return posted request object without products set, with request status set to pending.
+     */
+    public Request postNewRequest(Request reqToPost) {
+        return postNewRequestStoredProc.execute(reqToPost);
+
+    }
+
+    /**
+     * After the request has been made, populates the products_requests many to many join table
+     * and adds these products with pending status to the request.
+     *
+     * @param id A valid product id
+     * @param postedReq A request object, with id set
+     * @return Updated request object containing that product with a product status of pending.
+     */
+    public Request addProductToRequest(int id, Request postedReq) {
+        return addProductToRequestStoredProc.execute(id, postedReq);
+    }
+
+    /**
+     * Responsible for calling the stored procedure used to create a request in the database.
+     * The input request object should NOT have an id set as it will be overwritten by the
+     * database using autoincrement.
+     */
+    private class PostNewRequestStoredProc extends StoredProcedure {
+        private static final String procName = "req_requests_insert";
+
+        private PostNewRequestStoredProc() {
+            super(jdbcTemplate, procName);
+            declareParameter(new SqlInOutParameter("inout_notes", Types.VARCHAR));
+            declareParameter(new SqlInOutParameter("inout_dateCreated", Types.TIMESTAMP));
+            declareParameter(new SqlInOutParameter("inout_submittedBy_id", Types.INTEGER));
+            declareParameter(new SqlInOutParameter("inout_lastModified", Types.TIMESTAMP));
+            declareParameter(new SqlInOutParameter("inout_lastModifiedBy_id", Types.INTEGER));
+            declareParameter(new SqlInOutParameter("inout_status_id", Types.INTEGER));
+            declareParameter(new SqlOutParameter("out_id", Types.INTEGER));
+            compile();
+        }
+
+        /**
+         * Perform the stored procedure to post a request.
+         * @param req Request object to post.  The id value should be null as it will be
+         *            set by the database using autoincrement.
+         * @return posted Request object with id set.
+         */
+        private Request execute(Request req) {
+            Map<String, Object> inputs = new HashMap<>();
+            inputs.put("inout_notes", req.getNotes());
+            inputs.put("inout_dateCreated", req.getDateCreated());
+            inputs.put("inout_submittedBy_id", req.getSubmittedBy_employeeId());
+            inputs.put("inout_lastModified", req.getDateModified());
+            inputs.put("inout_lastModifiedBy_id", req.getLastModifiedBy_employeeId());
+            inputs.put("inout_status_id", req.getRequestStatus_id());
+
+            Map<String, Object> outputs= execute(inputs);
+
+            return makeRequestFromResponse(outputs);
+        }
+
+        /**
+         * Parse out a new Request object from a HashMap
+         * @param responseMap Keys and values from the stored procedure response
+         * @return new Request object with id set
+         */
+        private Request makeRequestFromResponse(Map<String, Object> responseMap) {
+            try {
+                Request req = new Request();
+                req.setId((long)responseMap.get("out_id"));
+                req.setNotes((String)responseMap.get("inout_notes"));
+                req.setDateCreated((Timestamp)responseMap.get("inout_dateCreated"));
+                req.setSubmittedBy_employeeId((int)responseMap.get("inout_submittedBy_id"));
+                req.setDateModified((Timestamp)responseMap.get("inout_lastModified"));
+                req.setLastModifiedBy_employeeId((int)responseMap.get("inout_lastModifiedBy_id"));
+                req.setRequestStatus_id((long)responseMap.get("inout_status_id"));
+                return req;
+            } catch (ClassCastException e) {
+                System.err.println("Class cast exception in addProductToRequest.makeRequestFromResponse, check DB");
+                throw new TypeMismatchDataAccessException(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Responsible for calling the stored procedure to update the products_requests table and populating
+     * Requests with RequestProducts;
+     */
+    private class AddProductToRequestStoredProc extends StoredProcedure {
+        private static final String procName = "req_productInRequest_insert";
+
+        private AddProductToRequestStoredProc() {
+            super(jdbcTemplate, procName);
+            declareParameter(new SqlParameter("in_request_id", Types.INTEGER));
+            declareParameter(new SqlInOutParameter("inout_product_id", Types.INTEGER));
+            declareParameter(new SqlInOutParameter("inout_product_status_id", Types.INTEGER));
+            declareParameter(new SqlOutParameter("out_product_name", Types.VARCHAR));
+            compile();
+        }
+
+        /**
+         * Perform the stored procedure to add a list of RequestProducts to a request.  At this point
+         * request should have an id set, but not a list of requested products
+         * @param prodId Id number of product to add.
+         * @param req Request object to put requested products in
+         * @return Request with RequestedProduct in it.
+         */
+        private Request execute(int prodId, Request req) {
+            Map<String, Object> inputs = new HashMap<>();
+            inputs.put("in_request_id", req.getId());
+            inputs.put("inout_product_id", prodId);
+            inputs.put("inout_product_status_id", 1);       // TODO Hardcoded product status value until enum set
+
+            Map<String, Object> outputs = execute(inputs);
+
+            return addRequestProductToRequest(outputs, req);
+        }
+
+        /**
+         * Given a hashmap containing a product and product status info, make these into a RequestProduct
+         * and add it to the request.  The requested products are all set to pending.
+         * @param responseMap HashMap contaning response information.
+         * @param req Request object to have products added to.
+         * @return updated Request object
+         */
+        private Request addRequestProductToRequest(Map<String, Object> responseMap, Request req) {
+            try {
+                Product p = new Product();
+                p.setId((long) responseMap.get("inout_product_id"));
+                p.setName((String) responseMap.get("out_product_name"));
+
+                long pStatusId = (long) responseMap.get("inout_product_status_id");
+
+                RequestProduct rp = new RequestProduct();
+                rp.setProduct(p);
+                rp.setProductStatus_id(pStatusId);
+
+                if (req.getProducts() == null) {
+                    List<RequestProduct> prodList = new ArrayList<>();
+                    prodList.add(rp);
+                    req.setProducts(prodList);
+                } else {
+                    req.getProducts().add(rp);
+                }
+                return req;
+
+            } catch (ClassCastException e) {
+                System.err.println("Class cast exception in AddProductToRequestStoredProc.addRequestProductToRequest, check DB");
+                throw new TypeMismatchDataAccessException(e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/coastcapitalsavings/mvc/repositories/RequestRepository.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/repositories/RequestRepository.java
@@ -106,7 +106,7 @@ public class RequestRepository {
 
             Map<String, Object> outputs= execute(inputs);
 
-            return makeRequestFromResponse(outputs);
+            return mapResponseToRequest(outputs);
         }
 
         /**
@@ -114,7 +114,7 @@ public class RequestRepository {
          * @param responseMap Keys and values from the stored procedure response
          * @return new Request object with id set
          */
-        private Request makeRequestFromResponse(Map<String, Object> responseMap) {
+        private Request mapResponseToRequest(Map<String, Object> responseMap) {
             try {
                 Request req = new Request();
                 req.setId((long)responseMap.get("out_id"));
@@ -126,7 +126,7 @@ public class RequestRepository {
                 req.setRequestStatus_id((long)responseMap.get("inout_status_id"));
                 return req;
             } catch (ClassCastException e) {
-                System.err.println("Class cast exception in addProductToRequest.makeRequestFromResponse, check DB");
+                System.err.println("Class cast exception in addProductToRequest.mapResponseToRequest, check DB");
                 throw new TypeMismatchDataAccessException(e.getMessage());
             }
         }
@@ -163,17 +163,17 @@ public class RequestRepository {
 
             Map<String, Object> outputs = execute(inputs);
 
-            return addRequestProductToRequest(outputs, req);
+            return addRequestProductToUpdatedRequest(outputs, req);
         }
 
         /**
-         * Given a hashmap containing a product and product status info, make these into a RequestProduct
-         * and add it to the request.  The requested products are all set to pending.
-         * @param responseMap HashMap contaning response information.
+         * Given a map containing a product and product status info, make each pair into a RequestProduct
+         * and add it to the Request.  The requested products are all set to pending.
+         * @param responseMap HashMap containing response information.
          * @param req Request object to have products added to.
          * @return updated Request object
          */
-        private Request addRequestProductToRequest(Map<String, Object> responseMap, Request req) {
+        private Request addRequestProductToUpdatedRequest(Map<String, Object> responseMap, Request req) {
             try {
                 Product p = new Product();
                 p.setId((long) responseMap.get("inout_product_id"));
@@ -185,7 +185,7 @@ public class RequestRepository {
                 rp.setProduct(p);
                 rp.setProductStatus_id(pStatusId);
 
-                if (req.getProducts() == null) {
+                if (req.getProducts() == null) {        // If Request.products has not been initialized yet, do it now
                     List<RequestProduct> prodList = new ArrayList<>();
                     prodList.add(rp);
                     req.setProducts(prodList);
@@ -195,7 +195,7 @@ public class RequestRepository {
                 return req;
 
             } catch (ClassCastException e) {
-                System.err.println("Class cast exception in AddProductToRequestStoredProc.addRequestProductToRequest, check DB");
+                System.err.println("Class cast exception in AddProductToRequestStoredProc.addRequestProductToUpdatedRequest, check DB");
                 throw new TypeMismatchDataAccessException(e.getMessage());
             }
         }

--- a/src/main/java/com/coastcapitalsavings/mvc/services/RequestService.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/services/RequestService.java
@@ -1,0 +1,36 @@
+package com.coastcapitalsavings.mvc.services;
+
+import com.coastcapitalsavings.mvc.models.Request;
+import com.coastcapitalsavings.mvc.repositories.RequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+
+
+@Service
+public class RequestService {
+
+    @Autowired
+    RequestRepository requestRepo;
+
+    public Request postNewRequest(String notes, int[] productsIds) {
+        Timestamp ts = new java.sql.Timestamp(System.currentTimeMillis());
+        int currentEmployee = 1;             // TODO: Hardcoded until spring security spike
+        Request req = new Request();
+        req.setNotes(notes);
+        req.setDateCreated(ts);
+        req.setDateModified(ts);
+        req.setSubmittedBy_employeeId(currentEmployee);
+        req.setLastModifiedBy_employeeId(currentEmployee);
+        req.setRequestStatus_id(1);         // TODO:  Hardcoded until status enum sorted out
+
+        Request postedRequest = requestRepo.postNewRequest(req);
+
+        for (int id : productsIds) {
+            requestRepo.addProductToRequest(id, postedRequest);
+        }
+
+        return postedRequest;
+    }
+}

--- a/src/main/java/com/coastcapitalsavings/mvc/services/RequestsService.java
+++ b/src/main/java/com/coastcapitalsavings/mvc/services/RequestsService.java
@@ -1,8 +1,0 @@
-package com.coastcapitalsavings.mvc.services;
-
-public class RequestsService {
-
-    public RequestsService() {
-
-    }
-}

--- a/src/main/java/com/coastcapitalsavings/util/Responses.java
+++ b/src/main/java/com/coastcapitalsavings/util/Responses.java
@@ -1,0 +1,11 @@
+package com.coastcapitalsavings.util;
+
+/**
+ * Possible response messages to accompany response codes;
+ */
+public enum Responses {
+    INVALID_PARAMETER_LENGTH,
+    MISSING_REQUIRED_PARAMETER,
+    INTERNAL_SERVER_ERROR,
+
+}

--- a/src/main/java/com/coastcapitalsavings/util/serializers/JsonTimeStampSerializer.java
+++ b/src/main/java/com/coastcapitalsavings/util/serializers/JsonTimeStampSerializer.java
@@ -1,0 +1,27 @@
+package com.coastcapitalsavings.util.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+
+/**
+ * Serializes Timestamps into a more readable format instead of milliseconds.
+ */
+@Component
+public class JsonTimeStampSerializer extends JsonSerializer<Timestamp> {
+
+    private static final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss");
+
+    @Override
+    public void serialize(Timestamp value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        String formattedDate = dateTimeFormat.format(value);
+        gen.writeString(formattedDate);
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 # Keep the connection alive if idle for a long time (needed in production)
 spring.datasource.testWhileIdle = true
 spring.datasource.validationQuery = SELECT 1
+spring.datasource.separator=^;
 security.ignored=/**

--- a/src/main/resources/schema.dev
+++ b/src/main/resources/schema.dev
@@ -137,12 +137,14 @@ FOREIGN KEY (product_status_id) REFERENCES product_statuses(id)
 # Created On:  	2017-2-20
 #---------------------------------------------------------------------------------------------
 
-DROP PROCEDURE IF EXISTS req_categories_getAll
+DELIMITER $$
+DROP PROCEDURE IF EXISTS req_categories_getAll $$
 CREATE PROCEDURE req_categories_getAll
 	()
 	BEGIN
 		select id, name from categories;
-	END ^;
+	END $$
+DELIMITER ;
 
 
 #---------------------------------------------------------------------------------------------
@@ -163,7 +165,8 @@ CREATE PROCEDURE req_categories_getAll
 # Created On:  	2017-2-20
 #---------------------------------------------------------------------------------------------
 
-DROP PROCEDURE IF EXISTS req_requests_insert
+DELIMITER $$
+DROP PROCEDURE IF EXISTS req_requests_insert $$
 CREATE PROCEDURE req_requests_insert
 	(
 		INOUT inout_notes VARCHAR(250),
@@ -177,7 +180,8 @@ CREATE PROCEDURE req_requests_insert
 	BEGIN
 		INSERT INTO requests VALUES (null, inout_notes, inout_dateCreated, inout_submittedBy_id, inout_lastModified, inout_lastModifiedBy_id, inout_status_id);
 		SELECT LAST_INSERT_ID() INTO out_id;
-	END ^;
+	END $$
+DELIMITER ;
 
 
 
@@ -196,8 +200,8 @@ CREATE PROCEDURE req_requests_insert
 # Created By:  	Chris Semiao
 # Created On:  	2017-2-21
 #---------------------------------------------------------------------------------------------
-
-DROP PROCEDURE IF EXISTS req_productInRequest_insert
+DELIMITER $$
+DROP PROCEDURE IF EXISTS req_productInRequest_insert $$
 CREATE PROCEDURE req_productInRequest_insert
 	(
 		IN in_request_id INT UNSIGNED,
@@ -208,4 +212,5 @@ CREATE PROCEDURE req_productInRequest_insert
 	BEGIN
 		INSERT INTO products_requests VALUES (null, in_request_id, inout_product_id, inout_product_status_id);
 		SELECT name INTO out_product_name FROM products WHERE id = inout_product_id;
-	END ^;
+	END $$
+DELIMITER ;

--- a/src/main/resources/schema.dev
+++ b/src/main/resources/schema.dev
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS employees (
  lName VARCHAR(255) NOT NULL,
  email VARCHAR(255) NOT NULL,
  reportsTo_id INT,
- costCenter_id INT UNSIGNED,
+ costCenter_id INT UNSIGNED NOT NULL,
 
  PRIMARY KEY (id),
  FOREIGN KEY (reportsTo_id) REFERENCES employees(id),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -111,7 +111,7 @@ FOREIGN KEY (status_id) REFERENCES request_statuses(id)
 );
 
 CREATE TABLE IF NOT EXISTS products_requests (
-id INT UNSIGNED,
+id INT UNSIGNED AUTO_INCREMENT,
 request_id INT UNSIGNED,
 product_id INT UNSIGNED,
 product_status_id INT UNSIGNED,
@@ -143,6 +143,75 @@ CREATE PROCEDURE req_categories_getAll
 	()
 	BEGIN
 		select id, name from categories;
+	END $$
+
+DELIMITER ;
+
+/*------------------------------------------------------------------------------------------
+Description: 	Insert a request and returns it with autoincremented id set.
+
+Called By:  	Coast Capital Requisitioning Application
+
+Parameters: 	inout_notes 				VARCHAR(255),
+							inout_dateCreated			DATETIME,
+							inout_submittedBy_id 		INT,
+							inout_lastModified 		DATETIME,
+							inout_lastModifiedBy_id 	INT,
+							inout_status_id			INT,
+
+Returns:    	request record
+
+Created By:  	Chris Semiao
+Created On:  	2017-2-20
+---------------------------------------------------------------------------------------------*/
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS req_requests_insert $$
+CREATE PROCEDURE req_requests_insert
+	(
+		INOUT inout_notes VARCHAR(250),
+		INOUT inout_dateCreated DATETIME,
+		INOUT inout_submittedBy_id INT,
+		INOUT inout_lastModified DATETIME,
+		INOUT inout_lastModifiedBy_id INT,
+		INOUT inout_status_id INT UNSIGNED,
+		OUT out_id INT UNSIGNED
+	)
+	BEGIN
+		INSERT INTO requests VALUES (null, inout_notes, inout_dateCreated, inout_submittedBy_id, inout_lastModified, inout_lastModifiedBy_id, inout_status_id);
+		SELECT LAST_INSERT_ID() INTO out_id;
+	END $$
+
+DELIMITER ;
+
+/*------------------------------------------------------------------------------------------
+Description: 	Insert a product into a request and return the product and its status
+
+Called By:  	Coast Capital Requisitioning Application
+
+Parameters: 	in_request_id 				INT UNSIGNED,
+				inout_product_id 			INT UNSIGNED,
+				inout_product_status_id 	INT UNSIGNED,
+
+Returns:    	product record
+				product_status record for product
+
+Created By:  	Chris Semiao
+Created On:  	2017-2-21
+---------------------------------------------------------------------------------------------*/
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS req_productInRequest_insert $$
+CREATE PROCEDURE req_productInRequest_insert
+	(
+		IN in_request_id INT UNSIGNED,
+		INOUT inout_product_id INT UNSIGNED,
+		INOUT inout_product_status_id INT UNSIGNED,
+		OUT out_product_name VARCHAR(255)
+	)
+	BEGIN
+		INSERT INTO products_requests VALUES (null, in_request_id, inout_product_id, inout_product_status_id);
+		SELECT name INTO out_product_name FROM products WHERE id = inout_product_id;
 	END $$
 
 DELIMITER ;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,130 +1,129 @@
-# noinspection SqlNoDataSourceInspectionForFile
-DROP TABLE IF EXISTS products_categories;
-DROP TABLE IF EXISTS products_profiles;
-DROP TABLE IF EXISTS products_requests;
-DROP TABLE IF EXISTS product_statuses;
-DROP TABLE IF EXISTS profiles;
-DROP TABLE IF EXISTS categories;
-DROP TABLE IF EXISTS employees_roles;
-DROP TABLE IF EXISTS roles;
-DROP TABLE IF EXISTS requests;
-DROP TABLE IF EXISTS request_statuses;
-DROP TABLE IF EXISTS products;
-DROP TABLE IF EXISTS employees;
-DROP TABLE IF EXISTS cost_centers;
+DROP TABLE IF EXISTS products_categories^;
+DROP TABLE IF EXISTS products_profiles^;
+DROP TABLE IF EXISTS products_requests^;
+DROP TABLE IF EXISTS product_statuses^;
+DROP TABLE IF EXISTS profiles^;
+DROP TABLE IF EXISTS categories^;
+DROP TABLE IF EXISTS employees_roles^;
+DROP TABLE IF EXISTS roles^;
+DROP TABLE IF EXISTS requests^;
+DROP TABLE IF EXISTS request_statuses^;
+DROP TABLE IF EXISTS products^;
+DROP TABLE IF EXISTS employees^;
+DROP TABLE IF EXISTS cost_centers^;
 
 CREATE TABLE IF NOT EXISTS products (
 	id INT UNSIGNED AUTO_INCREMENT,
 	name VARCHAR(255),
 
 	PRIMARY KEY (id)
-);
+)^;
 
 CREATE TABLE IF NOT EXISTS profiles (
 	id INT UNSIGNED AUTO_INCREMENT,
 	name VARCHAR(255),
 
 	PRIMARY KEY (id)
-);
+)^;
 
 CREATE TABLE IF NOT EXISTS products_profiles (
 	product_id INT UNSIGNED,
 	profile_id INT UNSIGNED,
 
 	PRIMARY KEY (product_id, profile_id)
-);
+)^;
 
 CREATE TABLE IF NOT EXISTS categories (
 	id INT UNSIGNED AUTO_INCREMENT,
 	name VARCHAR(255),
 
 	PRIMARY KEY (id)
-);
+)^;
 
 CREATE TABLE IF NOT EXISTS products_categories (
-product_id INT UNSIGNED,
-category_id INT UNSIGNED,
+	product_id INT UNSIGNED,
+	category_id INT UNSIGNED,
 
-PRIMARY KEY (product_id, category_id)
-);
+	PRIMARY KEY (product_id, category_id)
+)^;
 
 CREATE TABLE IF NOT EXISTS product_statuses (
-id INT UNSIGNED AUTO_INCREMENT,
-status VARCHAR(255),
-PRIMARY KEY (id)
-);
+	id INT UNSIGNED AUTO_INCREMENT,
+	status VARCHAR(255),
+	PRIMARY KEY (id)
+)^;
 
 CREATE TABLE IF NOT EXISTS cost_centers (
-id INT UNSIGNED AUTO_INCREMENT,
-name VARCHAR(255),
+	id INT UNSIGNED AUTO_INCREMENT,
+	name VARCHAR(255),
 
-PRIMARY KEY (id)
-);
+	PRIMARY KEY (id)
+)^;
 
 CREATE TABLE IF NOT EXISTS request_statuses (
-id INT UNSIGNED AUTO_INCREMENT,
-status VARCHAR(255),
+	id INT UNSIGNED AUTO_INCREMENT,
+	status VARCHAR(255),
 
-PRIMARY KEY (id)
-);
+	PRIMARY KEY (id)
+)^;
 
 CREATE TABLE IF NOT EXISTS employees (
- id INT,
- fName VARCHAR(255) NOT NULL,
- lName VARCHAR(255) NOT NULL,
- email VARCHAR(255) NOT NULL,
- reportsTo_id INT,
- costCenter_id INT UNSIGNED,
+	id INT,
+	fName VARCHAR(255) NOT NULL,
+	lName VARCHAR(255) NOT NULL,
+	email VARCHAR(255) NOT NULL,
+	reportsTo_id INT,
+	costCenter_id INT UNSIGNED NOT NULL,
 
- PRIMARY KEY (id),
- FOREIGN KEY (reportsTo_id) REFERENCES employees(id),
- FOREIGN KEY (costCenter_id) REFERENCES cost_centers(id)
-);
+	PRIMARY KEY (id),
+	FOREIGN KEY (reportsTo_id) REFERENCES employees(id),
+	FOREIGN KEY (costCenter_id) REFERENCES cost_centers(id)
+)^;
 
 CREATE TABLE IF NOT EXISTS roles (
-id INT UNSIGNED AUTO_INCREMENT,
-name VARCHAR(255),
+	id INT UNSIGNED AUTO_INCREMENT,
+	name VARCHAR(255),
 
-PRIMARY KEY (id)
-);
+	PRIMARY KEY (id)
+)^;
 
 CREATE TABLE IF NOT EXISTS employees_roles (
-employee_id INT,
-role_id INT UNSIGNED,
+	employee_id INT,
+	role_id INT UNSIGNED,
 
-PRIMARY KEY (employee_id, role_id)
-);
+	PRIMARY KEY (employee_id, role_id)
+)^;
 
 CREATE TABLE IF NOT EXISTS requests (
-id INT UNSIGNED AUTO_INCREMENT,
-notes VARCHAR(255),
-dateCreated DATETIME NOT NULL,
-submittedBy_id INT NOT NULL,
-lastModified DATETIME NOT NULL,
-lastModifiedBy_id INT NOT NULL,
-status_id INT UNSIGNED NOT NULL,
+	id INT UNSIGNED AUTO_INCREMENT,
+	notes VARCHAR(255),
+	dateCreated DATETIME NOT NULL,
+	submittedBy_id INT NOT NULL,
+	lastModified DATETIME NOT NULL,
+	lastModifiedBy_id INT NOT NULL,
+	status_id INT UNSIGNED NOT NULL,
 
-PRIMARY KEY (id),
-FOREIGN KEY (submittedBy_id) REFERENCES employees(id),
-FOREIGN KEY (lastModifiedBy_id) REFERENCES employees(id),
-FOREIGN KEY (status_id) REFERENCES request_statuses(id)
-);
+	PRIMARY KEY (id),
+	FOREIGN KEY (submittedBy_id) REFERENCES employees(id),
+	FOREIGN KEY (lastModifiedBy_id) REFERENCES employees(id),
+	FOREIGN KEY (status_id) REFERENCES request_statuses(id)
+)^;
 
 CREATE TABLE IF NOT EXISTS products_requests (
-id INT UNSIGNED AUTO_INCREMENT,
-request_id INT UNSIGNED,
-product_id INT UNSIGNED,
-product_status_id INT UNSIGNED,
+	id INT UNSIGNED AUTO_INCREMENT,
+	request_id INT UNSIGNED,
+	product_id INT UNSIGNED,
+	product_status_id INT UNSIGNED,
 
-PRIMARY KEY (id, request_id),
-FOREIGN KEY (product_id) REFERENCES products(id),
-FOREIGN KEY (product_status_id) REFERENCES product_statuses(id)
-);
+	PRIMARY KEY (id, request_id),
+	FOREIGN KEY (product_id) REFERENCES products(id),
+	FOREIGN KEY (product_status_id) REFERENCES product_statuses(id)
+)^;
 
 #--------------------------------------------------------------------------------------------
 #  Stored Procedures
 #--------------------------------------------------------------------------------------------
-
+^;
 
 #--------------------------------------------------------------------------------------------
 # Description:  Generates listing of all product categories
@@ -136,14 +135,14 @@ FOREIGN KEY (product_status_id) REFERENCES product_statuses(id)
 # Created By:  	Chris Semiao, Felix Tso
 # Created On:  	2017-2-20
 #---------------------------------------------------------------------------------------------
+^;
+DROP PROCEDURE IF EXISTS req_categories_getAll^;
 
-DROP PROCEDURE IF EXISTS req_categories_getAll
 CREATE PROCEDURE req_categories_getAll
 	()
 	BEGIN
 		select id, name from categories;
 	END ^;
-
 
 #---------------------------------------------------------------------------------------------
 # Description: 	Insert a request and returns it with autoincremented id set.
@@ -162,8 +161,9 @@ CREATE PROCEDURE req_categories_getAll
 # Created By:  	Chris Semiao
 # Created On:  	2017-2-20
 #---------------------------------------------------------------------------------------------
+^;
+DROP PROCEDURE IF EXISTS req_requests_insert^;
 
-DROP PROCEDURE IF EXISTS req_requests_insert
 CREATE PROCEDURE req_requests_insert
 	(
 		INOUT inout_notes VARCHAR(250),
@@ -178,8 +178,6 @@ CREATE PROCEDURE req_requests_insert
 		INSERT INTO requests VALUES (null, inout_notes, inout_dateCreated, inout_submittedBy_id, inout_lastModified, inout_lastModifiedBy_id, inout_status_id);
 		SELECT LAST_INSERT_ID() INTO out_id;
 	END ^;
-
-
 
 #--------------------------------------------------------------------------------------------
 # Description: 	Insert a product into a request and return the product and its status
@@ -196,8 +194,9 @@ CREATE PROCEDURE req_requests_insert
 # Created By:  	Chris Semiao
 # Created On:  	2017-2-21
 #---------------------------------------------------------------------------------------------
+^;
+DROP PROCEDURE IF EXISTS req_productInRequest_insert^;
 
-DROP PROCEDURE IF EXISTS req_productInRequest_insert
 CREATE PROCEDURE req_productInRequest_insert
 	(
 		IN in_request_id INT UNSIGNED,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -121,50 +121,47 @@ FOREIGN KEY (product_id) REFERENCES products(id),
 FOREIGN KEY (product_status_id) REFERENCES product_statuses(id)
 );
 
-/*
-Schema Section
- */
+#--------------------------------------------------------------------------------------------
+#  Stored Procedures
+#--------------------------------------------------------------------------------------------
 
 
-/*------------------------------------------------------------------------------------------
-Description:  Generates listing of all product categories
-
-Called By:    Coast Capital Requisitioning Application
-Parameters: 	none
-Returns:    	recordset
-
-Created By:  	Chris Semiao, Felix Tso
-Created On:  	2017-2-20
----------------------------------------------------------------------------------------------*/
-DELIMITER $$
+#--------------------------------------------------------------------------------------------
+# Description:  Generates listing of all product categories
+#
+# Called By:    Coast Capital Requisitioning Application
+# Parameters: 	none
+# Returns:    	recordset
+#
+# Created By:  	Chris Semiao, Felix Tso
+# Created On:  	2017-2-20
+#---------------------------------------------------------------------------------------------
 
 DROP PROCEDURE IF EXISTS req_categories_getAll $$
 CREATE PROCEDURE req_categories_getAll
 	()
 	BEGIN
 		select id, name from categories;
-	END $$
+	END ^;
 
-DELIMITER ;
 
-/*------------------------------------------------------------------------------------------
-Description: 	Insert a request and returns it with autoincremented id set.
-
-Called By:  	Coast Capital Requisitioning Application
-
-Parameters: 	inout_notes 				VARCHAR(255),
-							inout_dateCreated			DATETIME,
-							inout_submittedBy_id 		INT,
-							inout_lastModified 		DATETIME,
-							inout_lastModifiedBy_id 	INT,
-							inout_status_id			INT,
-
-Returns:    	request record
-
-Created By:  	Chris Semiao
-Created On:  	2017-2-20
----------------------------------------------------------------------------------------------*/
-DELIMITER $$
+#---------------------------------------------------------------------------------------------
+# Description: 	Insert a request and returns it with autoincremented id set.
+#
+# Called By:  	Coast Capital Requisitioning Application
+#
+# Parameters: 	inout_notes 				VARCHAR(255),
+#							inout_dateCreated			DATETIME,
+#							inout_submittedBy_id 		INT,
+#							inout_lastModified 		DATETIME,
+#							inout_lastModifiedBy_id 	INT,
+#							inout_status_id			INT,
+#
+# Returns:    	request record
+#
+# Created By:  	Chris Semiao
+# Created On:  	2017-2-20
+#---------------------------------------------------------------------------------------------
 
 DROP PROCEDURE IF EXISTS req_requests_insert $$
 CREATE PROCEDURE req_requests_insert
@@ -180,26 +177,25 @@ CREATE PROCEDURE req_requests_insert
 	BEGIN
 		INSERT INTO requests VALUES (null, inout_notes, inout_dateCreated, inout_submittedBy_id, inout_lastModified, inout_lastModifiedBy_id, inout_status_id);
 		SELECT LAST_INSERT_ID() INTO out_id;
-	END $$
+	END ^;
 
-DELIMITER ;
 
-/*------------------------------------------------------------------------------------------
-Description: 	Insert a product into a request and return the product and its status
 
-Called By:  	Coast Capital Requisitioning Application
-
-Parameters: 	in_request_id 				INT UNSIGNED,
-				inout_product_id 			INT UNSIGNED,
-				inout_product_status_id 	INT UNSIGNED,
-
-Returns:    	product record
-				product_status record for product
-
-Created By:  	Chris Semiao
-Created On:  	2017-2-21
----------------------------------------------------------------------------------------------*/
-DELIMITER $$
+#--------------------------------------------------------------------------------------------
+# Description: 	Insert a product into a request and return the product and its status
+#
+# Called By:  	Coast Capital Requisitioning Application
+#
+# Parameters: 	in_request_id 				INT UNSIGNED,
+#				inout_product_id 			INT UNSIGNED,
+#				inout_product_status_id 	INT UNSIGNED,
+#
+# Returns:    	product record
+#				product_status record for product
+#
+# Created By:  	Chris Semiao
+# Created On:  	2017-2-21
+#---------------------------------------------------------------------------------------------
 
 DROP PROCEDURE IF EXISTS req_productInRequest_insert $$
 CREATE PROCEDURE req_productInRequest_insert
@@ -212,6 +208,4 @@ CREATE PROCEDURE req_productInRequest_insert
 	BEGIN
 		INSERT INTO products_requests VALUES (null, in_request_id, inout_product_id, inout_product_status_id);
 		SELECT name INTO out_product_name FROM products WHERE id = inout_product_id;
-	END $$
-
-DELIMITER ;
+	END ^;


### PR DESCRIPTION
Enabled POST to /requests.  Uses hardcoded userIds and statuses and it does basic parameter checking.  The former because we don't know who is logged on at this point.  The latter because this should probably be enumerated.  

Added a new RequestProduct object to replace HashMap<Product, int> in Request with List<RequestProduct>.  This was to avoid having to painfully write a HashMap JSON serializer for Jackson to generate the keys in the response properly.

Refactored models (int -> long) because Java seems to treat unsigned ints as longs and will throw casting errors every tim the y are hit.

Added a new enum for responses, so that they remain consistent.  Can be expanded by anyone, shape, or size can modify it.

Updated schema.sql to fix an missing auto_increment on products_requests, and added two more stored procedures.